### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock


### PR DESCRIPTION
I've noticed that a `.gitignore` file is missing from this repository.
This pull requests adds one that hides the `target` directory and the `Cargo.lock` file from git.