### PR TITLE
"tockloader listen" proof of concept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 bytes = "1.4.0"
 clap = { version = "4.1.1", features = ["cargo"] }
+console = "0.15.5"
 futures = "0.3.28"
 tokio = { version ="1.28.0", features= ["full"] }
 tokio-serial = "5.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "1.4.0"
 clap = { version = "4.1.1", features = ["cargo"] }
+futures = "0.3.28"
+tokio = { version ="1.28.0", features= ["full"] }
+tokio-serial = "5.4.4"
+tokio-util = {version = "0.7.8", features = ["full"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{arg, crate_version, Command, value_parser};
+use clap::{arg, crate_version, value_parser, Command};
 
 /// Create the [command](clap::Command) object which will handle all of the command line arguments.
 pub fn make_cli() -> Command {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{arg, crate_version, Command};
+use clap::{arg, crate_version, Command, value_parser};
 
 /// Create the [command](clap::Command) object which will handle all of the command line arguments.
 pub fn make_cli() -> Command {
@@ -39,7 +39,7 @@ fn get_app_args() -> Vec<clap::Arg> {
 /// with channels and computer-board communication.
 fn get_channel_args() -> Vec<clap::Arg> {
     vec![
-        arg!(-p --port "The serial port or device name to use"),
+        arg!(-p --port <PORT> "The serial port or device name to use"),
         arg!(--serial "Use the serial bootloader to flash")
             .action(clap::ArgAction::SetTrue),
         arg!(--jlink "Use JLinkExe to flash")
@@ -65,6 +65,7 @@ fn get_channel_args() -> Vec<clap::Arg> {
         arg!(--"page-size" <SIZE> "Explicitly specify how many bytes in a flash page")
             .default_value("0"),
         arg!(--"baud-rate" <RATE> "If using serial, set the target baud rate")
+            .value_parser(value_parser!(u32))
             .default_value("115200"),
         arg!(--"no-bootloader-entry" "Tell Tockloader to assume the bootloader is already active")
             .action(clap::ArgAction::SetTrue),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ fn get_subcommands() -> Vec<Command> {
         .about("Open a terminal to receive UART data")
         .args(get_app_args())
         .args(get_channel_args())
-        .arg_required_else_help(true)]
+        .arg_required_else_help(false)]
 }
 
 /// Generate all of the [arguments](clap::Arg) that are required by subcommands which work with apps.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> tokio_serial::Result<()> {
         Some(("listen", sub_matches)) => {
             let port = sub_matches.get_one::<String>("port").unwrap();
             let baud_rate = *sub_matches.get_one::<u32>("baud-rate").unwrap();
-            
+
             println!("Got the listen subcommand");
             let stream = open_port(port.to_string(), baud_rate)?;
             run_terminal(stream).await;

--- a/src/serial_interface.rs
+++ b/src/serial_interface.rs
@@ -1,13 +1,12 @@
 use futures::stream::StreamExt;
 use std::io::Write;
-use std::{env, io, str};
-use tokio_util::codec::{Decoder, Encoder};
+use std::{io, str};
+use tokio_util::codec::Decoder;
 
 use bytes::BytesMut;
 use tokio_serial::SerialPortBuilderExt;
 
-
-use tokio_serial::{SerialStream};
+use tokio_serial::SerialStream;
 
 struct LineCodec;
 
@@ -16,37 +15,38 @@ impl Decoder for LineCodec {
     type Error = io::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        // let newline = src.as_ref().iter().position(|b| *b == b'\n');
-        // if let Some(n) = newline {
-        //     let line = src.split_to(n + 1);
-        //     return match str::from_utf8(line.as_ref()) {
-        //         Ok(s) => Ok(Some(s.to_string())),
-        //         Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid String")),
-        //     };
-        // }
-        // Ok(None)
         if src.is_empty() {
             return Ok(None);
         }
-        let result = match str::from_utf8(&src) {
+
+        // Read everything you can, and interpret it as a string.
+        // TODO: Note that this can fail if we try to decode in the middle of a multi-byte UTF-8 Character.
+        // We could wait for more output, or use this <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#method.valid_up_to>
+        let result = match str::from_utf8(src) {
             Ok(s) => Ok(Some(s.to_string())),
             Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid String")),
         };
         src.clear();
-        return result;
+        result
     }
 }
 
-pub fn open_port(path: String, baud_rate:u32) -> tokio_serial::Result<SerialStream> {
+pub fn open_port(path: String, baud_rate: u32) -> tokio_serial::Result<SerialStream> {
     // Is it async? It can't be awaited...
+    // TODO: What if we don't know the port? We need to copy over the implemenntation from the python version
     tokio_serial::new(path, baud_rate).open_native_async()
 }
 
 pub async fn run_terminal(stream: SerialStream) {
+    // TODO: What if there is another instance of tockloader open? Check the python implementation
+
     let mut reader = LineCodec.framed(stream);
+    // TODO: Spawn this into its own task, so that we may read and write at the same time.
+    // TODO: Can we hijack CTRL+C so that we can exit cleanly?
     while let Some(line_result) = reader.next().await {
         let line = line_result.expect("Failed to read line");
         print!("{}", line);
+        // We need to flush the buffer because the "tock>" prompt does not have a newline.
         io::stdout().flush().unwrap();
     }
 }

--- a/src/serial_interface.rs
+++ b/src/serial_interface.rs
@@ -24,7 +24,10 @@ impl Decoder for LineCodec {
         // TODO: Note that this can fail if we try to decode in the middle of a multi-byte UTF-8 Character.
         // We could wait for more output, or use this <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#method.valid_up_to>
         let result = match str::from_utf8(src) {
-            Ok(s) => Ok(Some(s.to_string())),
+            Ok(s) => {
+                let output = s.replace('\n', "\r\n");
+                Ok(Some(output))
+            }
             Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid String")),
         };
         src.clear();
@@ -90,7 +93,6 @@ pub async fn write_to_serial(
             println!("Session aborted");
             break;
         }
-
         // println!("Sending {} | {}", buf, buf as u8);
         writer.send(buf.into()).await.expect("BBBBBB");
     }

--- a/src/serial_interface.rs
+++ b/src/serial_interface.rs
@@ -1,14 +1,15 @@
-use futures::stream::StreamExt;
+use futures::stream::{SplitSink, SplitStream, StreamExt};
+use futures::SinkExt;
 use std::io::Write;
 use std::{io, str};
-use tokio_util::codec::Decoder;
+use tokio_util::codec::{Decoder, Encoder, Framed};
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
+use console::Term;
 use tokio_serial::SerialPortBuilderExt;
-
 use tokio_serial::SerialStream;
 
-struct LineCodec;
+pub struct LineCodec;
 
 impl Decoder for LineCodec {
     type Item = String;
@@ -31,6 +32,15 @@ impl Decoder for LineCodec {
     }
 }
 
+impl Encoder<String> for LineCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, _item: String, _dst: &mut BytesMut) -> Result<(), Self::Error> {
+        _dst.put(_item.as_bytes());
+        Ok(())
+    }
+}
+
 pub fn open_port(path: String, baud_rate: u32) -> tokio_serial::Result<SerialStream> {
     // Is it async? It can't be awaited...
     // TODO: What if we don't know the port? We need to copy over the implemenntation from the python version
@@ -38,9 +48,20 @@ pub fn open_port(path: String, baud_rate: u32) -> tokio_serial::Result<SerialStr
 }
 
 pub async fn run_terminal(stream: SerialStream) {
+    let (writer, reader) = LineCodec.framed(stream).split();
+    let a = tokio::spawn(async move {
+        read_from_serial(reader).await;
+    });
+    tokio::spawn(async move {
+        write_to_serial(writer).await;
+    });
+
+    a.await.unwrap();
+}
+
+pub async fn read_from_serial(mut reader: SplitStream<Framed<SerialStream, LineCodec>>) {
     // TODO: What if there is another instance of tockloader open? Check the python implementation
 
-    let mut reader = LineCodec.framed(stream);
     // TODO: Spawn this into its own task, so that we may read and write at the same time.
     // TODO: Can we hijack CTRL+C so that we can exit cleanly?
     while let Some(line_result) = reader.next().await {
@@ -49,4 +70,34 @@ pub async fn run_terminal(stream: SerialStream) {
         // We need to flush the buffer because the "tock>" prompt does not have a newline.
         io::stdout().flush().unwrap();
     }
+}
+
+pub async fn write_to_serial(
+    mut writer: SplitSink<Framed<SerialStream, LineCodec>, std::string::String>,
+) {
+    let term = Term::stdout();
+
+    loop {
+        let buf = match term.read_char() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Read error: {e}");
+                break;
+            }
+        };
+
+        if buf as u8 == 0x03 {
+            println!("Session aborted");
+            break;
+        }
+
+        // println!("Sending {} | {}", buf, buf as u8);
+        writer.send(buf.into()).await.expect("BBBBBB");
+    }
+    // loop {
+    //     let mut buffer = String::new();
+    //     let _ = io::stdin().read_line(&mut buffer);
+    //     writer.send(buffer).await.expect("AAAaaaa");
+    //     writer.flush().await.expect("BBBBBBbb");
+    // }
 }

--- a/src/serial_interface.rs
+++ b/src/serial_interface.rs
@@ -1,0 +1,52 @@
+use futures::stream::StreamExt;
+use std::io::Write;
+use std::{env, io, str};
+use tokio_util::codec::{Decoder, Encoder};
+
+use bytes::BytesMut;
+use tokio_serial::SerialPortBuilderExt;
+
+
+use tokio_serial::{SerialStream};
+
+struct LineCodec;
+
+impl Decoder for LineCodec {
+    type Item = String;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        // let newline = src.as_ref().iter().position(|b| *b == b'\n');
+        // if let Some(n) = newline {
+        //     let line = src.split_to(n + 1);
+        //     return match str::from_utf8(line.as_ref()) {
+        //         Ok(s) => Ok(Some(s.to_string())),
+        //         Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid String")),
+        //     };
+        // }
+        // Ok(None)
+        if src.is_empty() {
+            return Ok(None);
+        }
+        let result = match str::from_utf8(&src) {
+            Ok(s) => Ok(Some(s.to_string())),
+            Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Invalid String")),
+        };
+        src.clear();
+        return result;
+    }
+}
+
+pub fn open_port(path: String, baud_rate:u32) -> tokio_serial::Result<SerialStream> {
+    // Is it async? It can't be awaited...
+    tokio_serial::new(path, baud_rate).open_native_async()
+}
+
+pub async fn run_terminal(stream: SerialStream) {
+    let mut reader = LineCodec.framed(stream);
+    while let Some(line_result) = reader.next().await {
+        let line = line_result.expect("Failed to read line");
+        print!("{}", line);
+        io::stdout().flush().unwrap();
+    }
+}

--- a/src/serial_interface.rs
+++ b/src/serial_interface.rs
@@ -6,7 +6,7 @@ use std::{io, str};
 
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
-use bytes::{BufMut, BytesMut, Buf};
+use bytes::{Buf, BufMut, BytesMut};
 use console::Term;
 use tokio_serial::SerialPortBuilderExt;
 use tokio_serial::SerialStream;
@@ -14,7 +14,7 @@ use tokio_serial::SerialStream;
 pub struct LineCodec;
 
 impl LineCodec {
-    fn clean_input(input: &str ) -> String {
+    fn clean_input(input: &str) -> String {
         input.replace('\n', "\r\n")
     }
 }
@@ -29,7 +29,7 @@ impl Decoder for LineCodec {
         }
 
         // Read everything you can, and interpret it as a string.
-        match str::from_utf8(&source) {
+        match str::from_utf8(source) {
             Ok(utf8_string) => {
                 let output = LineCodec::clean_input(utf8_string);
                 source.clear();
@@ -49,8 +49,14 @@ impl Decoder for LineCodec {
                         let output = LineCodec::clean_input(utf8_string);
                         source.advance(index);
                         Ok(Some(output))
-                    },
-                    Err(_) => Err(io::Error::new(io::ErrorKind::InvalidData, format!("Couldn't parse input as UTF8. Last valid index: {}. Buffer: {:?}",index,source))),
+                    }
+                    Err(_) => Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "Couldn't parse input as UTF8. Last valid index: {}. Buffer: {:?}",
+                            index, source
+                        ),
+                    )),
                 }
             }
         }

--- a/src/serial_interface.rs
+++ b/src/serial_interface.rs
@@ -199,7 +199,9 @@ pub async fn write_to_serial(
             console::Key::Tab => Some("\t".into()),
             console::Key::BackTab => Some("\t".into()),
             console::Key::Alt => None,
-            console::Key::Del => Some("\x7f".into()),
+            // In latest version of kernel (2023.08.25), the "del" ascii code (\x7F)
+            // is handled exactly as backspace (\x08). Proper del is this:
+            console::Key::Del => Some("\u{1B}[3~".into()),
             console::Key::Shift => None,
             console::Key::Insert => None,
             console::Key::PageUp => None,


### PR DESCRIPTION
This pull request is a WIP proof of concept for the "tockloader listen" subcommand.

Currently, I am able to listen on a given port for output (tested on a micro:bit v2). It works both on Windows and under WSL.

## Notes regarding implementation
This PR adds the following libraries:
- `tokio` - for creating async code
- `tokio-serial` - for reading and writing to serial
- `tokio-util`
- `bytes`

## Notes regarding the python version
The python version of 'tockloader listen' has a lot of functionalities and I'd like note down some of them here.
- [x] Automatic port detection
- [ ] Stops and Restarts automatically if another tockloader session starts
- [ ] Optionally timestamps and counts recieved messages
- [ ] Hijacks CTRL+C to close gracefully
- [ ] Attempts to auto-reconnect

While creating the proof of concept I'll attempt to implement as many of these functionalities as it is reasonable.